### PR TITLE
Fix Subscribe For Errors List

### DIFF
--- a/libs/reactive-forms-utils/package.json
+++ b/libs/reactive-forms-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-reactive-forms-utils",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"author": {
 		"email": "preston.j.lamb@gmail.com",
 		"name": "Preston Lamb",

--- a/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.html
+++ b/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.html
@@ -2,8 +2,10 @@
 	<ng-content></ng-content>
 
 	<ng-container *ngIf="rulesBroken">
-		<ng-container *ngIf="errorsList$">
-			<p [ngClass]="errorClasses" *ngFor="let error of errorsList$ | async">{{ error }}</p>
+		<ng-container *ngIf="errorsList$ | async as errorsList">
+			<ng-container *ngIf="errorsList && errorsList.length">
+				<p [ngClass]="errorClasses" *ngFor="let error of errorsList">{{ error }}</p>
+			</ng-container>
 		</ng-container>
 	</ng-container>
 </div>

--- a/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.spec.ts
+++ b/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.spec.ts
@@ -3,9 +3,10 @@ import { ControlErrorsDisplayComponent } from './control-errors-display.componen
 describe('ControlErrorsDisplayComponent', () => {
 	let component: ControlErrorsDisplayComponent;
 	const mockErrorMessages = {};
+	const mockDebounceTime = 0;
 
 	beforeEach(() => {
-		component = new ControlErrorsDisplayComponent(mockErrorMessages);
+		component = new ControlErrorsDisplayComponent(mockErrorMessages, mockDebounceTime);
 	});
 
 	it('should create', () => {

--- a/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.ts
+++ b/libs/reactive-forms-utils/src/lib/control-errors-display/control-errors-display.component.ts
@@ -1,7 +1,7 @@
 import { AfterContentInit, Component, ContentChild, Inject, Input } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { Observable, map, startWith } from 'rxjs';
-import { CustomErrorMessages, FORM_ERRORS } from '../custom-error-message-utils';
+import { Observable, debounceTime, map, startWith } from 'rxjs';
+import { CustomErrorMessages, FORM_ERRORS, FORM_ERRORS_DEBOUNCE_TIME } from '../custom-error-message-utils';
 
 @Component({
 	selector: 'ngx-control-errors-display',
@@ -23,12 +23,16 @@ export class ControlErrorsDisplayComponent implements AfterContentInit {
 
 	private _errorMessages: CustomErrorMessages = this._errors;
 
-	constructor(@Inject(FORM_ERRORS) private _errors: CustomErrorMessages) {}
+	constructor(
+		@Inject(FORM_ERRORS) private _errors: CustomErrorMessages,
+		@Inject(FORM_ERRORS_DEBOUNCE_TIME) private debounceTime: number,
+	) {}
 
 	ngAfterContentInit() {
 		if (this.control) {
 			this.errorsList$ = this.control.statusChanges?.pipe(
 				startWith(this.control.status),
+				debounceTime(this.debounceTime),
 				map(() => {
 					const errors = this.control.errors;
 

--- a/libs/reactive-forms-utils/src/lib/custom-error-message-utils.ts
+++ b/libs/reactive-forms-utils/src/lib/custom-error-message-utils.ts
@@ -34,3 +34,8 @@ export const FORM_ERRORS = new InjectionToken('FORM_ERRORS', {
 	providedIn: 'root',
 	factory: () => defaultCustomErrorMessages,
 });
+
+export const FORM_ERRORS_DEBOUNCE_TIME = new InjectionToken('FORM_ERRORS_DEBOUNCE_TIME', {
+	providedIn: 'root',
+	factory: () => 0,
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-reactive-form-utils",
-	"version": "1.1.0",
+	"version": "3.1.0",
 	"license": "MIT",
 	"scripts": {
 		"ng": "nx",


### PR DESCRIPTION
only subscribe to the errors list once, and provide an optional debounce time for showing the errors as an injection token