### PR TITLE
feat: add formStateSignal utility and update docs/demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,14 @@ Second is a second component that displays the form debug information on the scr
 You only need to pass in the form to the debug display component and it handles the rest.
 
 Third is the ability to determine which debug fields are returned or displayed. There is an type, `FormDebugField`, with several available fields that can be displayed. By default, all are displayed, but you can change that by providing an array of the desired fields to either the function or the component. 
+
+## Signals
+
+With the release of Angular v18, `AbstractControl` now has an `events` observable that emits all events that happen on the control. This library leverages that to provide a signal that emits the state of the form control.
+
+```ts
+const name = new FormControl('test');
+const nameState = formStateSignal(name);
+```
+
+The signal will emit the current state of the form control, including the value, status, errors, touched, dirty, valid, invalid, pending, disabled, and enabled properties.

--- a/apps/demo-app/src/app/app.component.html
+++ b/apps/demo-app/src/app/app.component.html
@@ -33,6 +33,8 @@
 	<main class="flex-grow py-8">
 		<div class="max-w-5xl mx-auto">
 			<ngx-reactive-form-utils-demo-form></ngx-reactive-form-utils-demo-form>
+			<hr class="my-8" />
+			<app-signal-demo></app-signal-demo>
 		</div>
 	</main>
 

--- a/apps/demo-app/src/app/app.module.ts
+++ b/apps/demo-app/src/app/app.module.ts
@@ -5,9 +5,10 @@ import { ControlErrorsDisplayComponent, FormDebugDisplayComponent } from 'ngx-re
 
 import { AppComponent } from './app.component';
 import { DemoFormComponent } from './demo-form/demo-form.component';
+import { SignalDemoComponent } from './signal-demo/signal-demo.component';
 
 @NgModule({
-	declarations: [AppComponent, DemoFormComponent],
+	declarations: [AppComponent, DemoFormComponent, SignalDemoComponent],
 	imports: [BrowserModule, ReactiveFormsModule, ControlErrorsDisplayComponent, FormDebugDisplayComponent],
 	providers: [],
 	bootstrap: [AppComponent],

--- a/apps/demo-app/src/app/signal-demo/signal-demo.component.html
+++ b/apps/demo-app/src/app/signal-demo/signal-demo.component.html
@@ -1,0 +1,17 @@
+<form [formGroup]="form" class="mx-auto flex flex-col gap-4 justify-center items-center">
+	<div class="flex gap-2 items-start">
+		<label class="pt-2" for="name">Name: </label>
+		<ngx-control-errors-display errorClasses="text-red-500 text-sm">
+			<input type="text" formControlName="name" class="border p-2 rounded" />
+		</ngx-control-errors-display>
+	</div>
+
+	<div class="flex flex-col gap-2 p-4 border rounded bg-gray-50">
+		<h3 class="font-bold">Signal State:</h3>
+		<p>Value: {{ nameState().value }}</p>
+		<p>Valid: {{ nameState().valid }}</p>
+		<p>Dirty: {{ nameState().dirty }}</p>
+		<p>Touched: {{ nameState().touched }}</p>
+		<p>Errors: {{ nameState().errors | json }}</p>
+	</div>
+</form>

--- a/apps/demo-app/src/app/signal-demo/signal-demo.component.ts
+++ b/apps/demo-app/src/app/signal-demo/signal-demo.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ControlErrorsDisplayComponent, formStateSignal } from '../../../../../libs/reactive-forms-utils/src/index';
+
+@Component({
+	selector: 'app-signal-demo',
+	templateUrl: './signal-demo.component.html',
+	standalone: false,
+})
+export class SignalDemoComponent {
+	private fb = inject(FormBuilder);
+
+	form = this.fb.group({
+		name: ['test', [Validators.required, Validators.minLength(3)]],
+	});
+
+	nameState = formStateSignal(this.form.get('name')!);
+}

--- a/apps/demo-app/src/main.ts
+++ b/apps/demo-app/src/main.ts
@@ -5,9 +5,9 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
-  enableProdMode();
+	enableProdMode();
 }
 
 platformBrowserDynamic()
-  .bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()], })
-  .catch((err) => console.error(err));
+	.bootstrapModule(AppModule)
+	.catch((err) => console.error(err));

--- a/libs/reactive-forms-utils/README.md
+++ b/libs/reactive-forms-utils/README.md
@@ -90,3 +90,14 @@ Second is a second component that displays the form debug information on the scr
 You only need to pass in the form to the debug display component and it handles the rest.
 
 Third is the ability to determine which debug fields are returned or displayed. There is an type, `FormDebugField`, with several available fields that can be displayed. By default, all are displayed, but you can change that by providing an array of the desired fields to either the function or the component. 
+
+## Signals
+
+With the release of Angular v18, `AbstractControl` now has an `events` observable that emits all events that happen on the control. This library leverages that to provide a signal that emits the state of the form control.
+
+```ts
+const name = new FormControl('test');
+const nameState = formStateSignal(name);
+```
+
+The signal will emit the current state of the form control, including the value, status, errors, touched, dirty, valid, invalid, pending, disabled, and enabled properties.

--- a/libs/reactive-forms-utils/package.json
+++ b/libs/reactive-forms-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-reactive-forms-utils",
-	"version": "5.0.0",
+	"version": "5.1.0",
 	"author": {
 		"email": "preston.j.lamb@gmail.com",
 		"name": "Preston Lamb",

--- a/libs/reactive-forms-utils/src/index.ts
+++ b/libs/reactive-forms-utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/custom-validators';
 export * from './lib/form-debug.util';
 
 export * from './lib/form-debug-display/form-debug-display.component';
+export * from './lib/signals';

--- a/libs/reactive-forms-utils/src/lib/signals.spec.ts
+++ b/libs/reactive-forms-utils/src/lib/signals.spec.ts
@@ -1,0 +1,75 @@
+import { Component, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { formStateSignal } from './signals';
+
+describe('formStateSignal', () => {
+	let control: FormControl<string | null>;
+
+	beforeEach(() => {
+		control = new FormControl('initial');
+	});
+
+	it('should return initial state', () => {
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(control);
+			expect(state().value).toBe('initial');
+			expect(state().valid).toBe(true);
+			expect(state().dirty).toBe(false);
+			expect(state().touched).toBe(false);
+		});
+	});
+
+	it('should update on value change', () => {
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(control);
+			control.setValue('new value');
+			expect(state().value).toBe('new value');
+		});
+	});
+
+	it('should update on status change (valid/invalid)', () => {
+		control.setValidators(Validators.required);
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(control);
+			expect(state().valid).toBe(true);
+
+			control.setValue('');
+			expect(state().valid).toBe(false);
+			expect(state().errors?.['required']).toBe(true);
+		});
+	});
+
+	it('should update on touched status', () => {
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(control);
+			expect(state().touched).toBe(false);
+
+			control.markAsTouched();
+			expect(state().touched).toBe(true);
+		});
+	});
+
+	it('should update on dirty status', () => {
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(control);
+			expect(state().dirty).toBe(false);
+
+			control.markAsDirty();
+			expect(state().dirty).toBe(true);
+		});
+	});
+
+	it('should work with FormGroup', () => {
+		const group = new FormGroup({
+			name: new FormControl(''),
+		});
+		runInInjectionContext(TestBed, () => {
+			const state = formStateSignal(group);
+			expect(state().value).toEqual({ name: '' });
+
+			group.get('name')?.setValue('updated');
+			expect(state().value).toEqual({ name: 'updated' });
+		});
+	});
+});

--- a/libs/reactive-forms-utils/src/lib/signals.ts
+++ b/libs/reactive-forms-utils/src/lib/signals.ts
@@ -1,0 +1,51 @@
+import { Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { AbstractControl, FormControlStatus, ValidationErrors } from '@angular/forms';
+import { map, startWith } from 'rxjs/operators';
+
+export interface FormState<T> {
+	value: T;
+	status: FormControlStatus;
+	errors: ValidationErrors | null;
+	touched: boolean;
+	dirty: boolean;
+	valid: boolean;
+	invalid: boolean;
+	pending: boolean;
+	disabled: boolean;
+	enabled: boolean;
+}
+
+export function formStateSignal<T>(control: AbstractControl<T>): Signal<FormState<T>> {
+	return toSignal(
+		control.events.pipe(
+			startWith(null),
+			map(() => ({
+				value: control.value,
+				status: control.status,
+				errors: control.errors,
+				touched: control.touched,
+				dirty: control.dirty,
+				valid: control.valid,
+				invalid: control.invalid,
+				pending: control.pending,
+				disabled: control.disabled,
+				enabled: control.enabled,
+			})),
+		),
+		{
+			initialValue: {
+				value: control.value,
+				status: control.status,
+				errors: control.errors,
+				touched: control.touched,
+				dirty: control.dirty,
+				valid: control.valid,
+				invalid: control.invalid,
+				pending: control.pending,
+				disabled: control.disabled,
+				enabled: control.enabled,
+			},
+		},
+	);
+}


### PR DESCRIPTION
Implement formStateSignal utility for reactive form state tracking. Update documentation and add demo component.